### PR TITLE
Fix Android crashing due to letterSpacing being invalid.

### DIFF
--- a/src/collections/human.js
+++ b/src/collections/human.js
@@ -17,77 +17,77 @@ const getStylesForColor = color => ({
     fontSize: 34,
     lineHeight: 41,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(34) : undefined,
+    letterSpacing: sanFranciscoSpacing(34),
     color: colors[color]
   },
   title1: {
     fontSize: 28,
     lineHeight: 34,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(28) : undefined,
+    letterSpacing: sanFranciscoSpacing(28),
     color: colors[color]
   },
   title2: {
     fontSize: 22,
     lineHeight: 28,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(22) : undefined,
+    letterSpacing: sanFranciscoSpacing(22),
     color: colors[color]
   },
   title3: {
     fontSize: 20,
     lineHeight: 25,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(20) : undefined,
+    letterSpacing: sanFranciscoSpacing(20),
     color: colors[color]
   },
   headline: {
     fontSize: 17,
     lineHeight: 22,
     ...systemWeights.semibold,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(17) : undefined,
+    letterSpacing: sanFranciscoSpacing(17),
     color: colors[color]
   },
   body: {
     fontSize: 17,
     lineHeight: 22,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(17) : undefined,
+    letterSpacing: sanFranciscoSpacing(17),
     color: colors[color]
   },
   callout: {
     fontSize: 16,
     lineHeight: 21,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(16) : undefined,
+    letterSpacing: sanFranciscoSpacing(16),
     color: colors[color]
   },
   subhead: {
     fontSize: 15,
     lineHeight: 20,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(15) : undefined,
+    letterSpacing: sanFranciscoSpacing(15),
     color: colors[color]
   },
   footnote: {
     fontSize: 13,
     lineHeight: 18,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(13) : undefined,
+    letterSpacing: sanFranciscoSpacing(13),
     color: colors[color]
   },
   caption1: {
     fontSize: 12,
     lineHeight: 16,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(12) : undefined,
+    letterSpacing: sanFranciscoSpacing(12),
     color: colors[color]
   },
   caption2: {
     fontSize: 11,
     lineHeight: 13,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(11) : undefined,
+    letterSpacing: sanFranciscoSpacing(11),
     color: colors[color]
   }
 });

--- a/src/collections/iOSUIKit.js
+++ b/src/collections/iOSUIKit.js
@@ -14,19 +14,19 @@ const getStylesForColor = color => {
     largeTitleEmphasized: {
       ...human[`largeTitle${colorSuffix}Object`],
       ...systemWeights.bold,
-      letterSpacing: Platform.OS === "ios" ? 0.41 : undefined
+      letterSpacing: 0.41
     },
     title3: human[`title3${colorSuffix}Object`],
     title3Emphasized: {
       ...human[`title3${colorSuffix}Object`],
       ...systemWeights.semibold,
-      letterSpacing: Platform.OS === "ios" ? 0.75 : undefined
+      letterSpacing: 0.75
     },
     body: human[`body${colorSuffix}Object`],
     bodyEmphasized: {
       ...human[`body${colorSuffix}Object`],
       ...systemWeights.semibold,
-      letterSpacing: Platform.OS === "ios" ? -0.41 : undefined
+      letterSpacing: -0.41
     },
     subhead: human[`subhead${colorSuffix}Object`],
     subheadShort: {
@@ -36,20 +36,20 @@ const getStylesForColor = color => {
     subheadEmphasized: {
       ...human[`subhead${colorSuffix}Object`],
       ...systemWeights.semibold,
-      letterSpacing: Platform.OS === "ios" ? -0.24 : undefined
+      letterSpacing: -0.24
     },
     callout: human[`callout${colorSuffix}Object`],
     footnote: human[`footnote${colorSuffix}Object`],
     footnoteEmphasized: {
       ...human[`footnote${colorSuffix}Object`],
       ...systemWeights.semibold,
-      letterSpacing: Platform.OS === "ios" ? -0.08 : undefined
+      letterSpacing: -0.08
     },
     caption2: human[`caption2${colorSuffix}Object`],
     caption2Emphasized: {
       ...human[`caption2${colorSuffix}Object`],
       ...systemWeights.semibold,
-      letterSpacing: Platform.OS === "ios" ? 0.06 : undefined
+      letterSpacing: 0.06
     }
   };
 };

--- a/src/collections/material.js
+++ b/src/collections/material.js
@@ -25,77 +25,77 @@ const getStylesForColor = color => ({
     fontSize: 112,
     lineHeight: 128,
     ...systemWeights.light,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(112) : undefined,
+    letterSpacing: sanFranciscoSpacing(112),
     color: colors[color].secondary
   },
   display3: {
     fontSize: 56,
     lineHeight: 64,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(56) : undefined,
+    letterSpacing: sanFranciscoSpacing(56),
     color: colors[color].secondary
   },
   display2: {
     fontSize: 45,
     lineHeight: 52,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(45) : undefined,
+    letterSpacing: sanFranciscoSpacing(45),
     color: colors[color].secondary
   },
   display1: {
     fontSize: 34,
     lineHeight: 40,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(34) : undefined,
+    letterSpacing: sanFranciscoSpacing(34),
     color: colors[color].secondary
   },
   headline: {
     fontSize: 24,
     lineHeight: 32,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(24) : undefined,
+    letterSpacing: sanFranciscoSpacing(24),
     color: colors[color].primary
   },
   title: {
     fontSize: 20,
     lineHeight: 28,
     ...systemWeights.semibold,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(20) : undefined,
+    letterSpacing: sanFranciscoSpacing(20),
     color: colors[color].primary
   },
   subheading: {
     fontSize: 16,
     lineHeight: 24,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(16) : undefined,
+    letterSpacing: sanFranciscoSpacing(16),
     color: colors[color].primary
   },
   body2: {
     fontSize: 14,
     lineHeight: 24,
     ...systemWeights.semibold,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(14) : undefined,
+    letterSpacing: sanFranciscoSpacing(14),
     color: colors[color].primary
   },
   body1: {
     fontSize: 14,
     lineHeight: 20,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(14) : undefined,
+    letterSpacing: sanFranciscoSpacing(14),
     color: colors[color].primary
   },
   caption: {
     fontSize: 12,
     lineHeight: 16,
     ...systemWeights.regular,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(12) : undefined,
+    letterSpacing: sanFranciscoSpacing(12),
     color: colors[color].secondary
   },
   button: {
     fontSize: 14,
     lineHeight: 20,
     ...systemWeights.semibold,
-    letterSpacing: Platform.OS === "ios" ? sanFranciscoSpacing(14) : undefined,
+    letterSpacing: sanFranciscoSpacing(14),
     color: colors[color].primary
   }
 });


### PR DESCRIPTION
I'm trying to use `style={human.largeTitle}` on Android and kittens die in a fiery flame with this error. I'm not sure I follow why we aren't just applying the same letter spacing across platforms hence this PR.

![_pcclf-t](https://user-images.githubusercontent.com/2807897/33787170-a9849be4-dc31-11e7-9e80-ae44153e2216.jpg)
