### PR TITLE
Fix anchor link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Absolutely! The helpers are very convenient to build your own text styles as
 they work around
 [the quirks of working with text styles on React Native](https://medium.com/@martin_adamko/react-native-quirks-2fb1ae0bbf80),
 even if you want to specify your own sizes and weights,
-[check them out!](#customization-helpers)
+[check them out!](#customization--helpers)
 
 #### Kerning is not 100% accurate on the Display sizes for the Material styles on Android
 


### PR DESCRIPTION
This tiny PR fixes the `Customization & Helpers` anchor link in the README.md