### PR TITLE
[web] Added support for Expo web

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "Pixel–perfect, native–looking typographic styles for React Native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "module": "src/index.js",
+  "sideEffects": false,
   "files": ["src/", "dist/"],
   "directories": {
     "example": "example"


### PR DESCRIPTION
Using modules that are compiled AOT causes compatability issues at scale. Because React Native uses Metro and web uses Webpack it's tricky to use different compilations together. 
The proposed change will enable tree shaking (dead code elimination) and cause the library to be compiled with the project's babel config (web only). Native won't be effected as `module` is a Webpack property.

Related: https://github.com/expo/expo-cli/issues/556